### PR TITLE
refactor(tracing): don't emit logs by default

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -2,7 +2,7 @@ use crate::account::Account;
 use crate::account_activity::AccountActivity;
 use std::collections::HashMap;
 use std::error::Error;
-use tracing::{error, warn};
+use tracing::warn;
 
 // TODO: This fn is public to be able to benchmark it. This should probably be handled with a bench 
 //       feature instead.

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -15,7 +15,7 @@ where
     for account_activity in activities {
         match account_activity {
             Err(err) => {
-                error!(error = ?err, "error parsing account activity record")
+                warn!(error = ?err, "error parsing account activity record")
             }
             Ok(activity) => {
                 let account = accounts


### PR DESCRIPTION
Ensure parser logs are only emitted when user sets log level below error.